### PR TITLE
Add local users' dnf directories lookup when looking for cache directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [DEV] Start adding unit tests
 
+### Fixes
+
+* Look for local users directories when trying to fetch data in cache when the main dnf cache is unreadable
+
 ## Version 0.3.0
 
 ### Breaking changes

--- a/src/commons.sh
+++ b/src/commons.sh
@@ -29,7 +29,7 @@ get_repo_cache_path() {
   
   # Use 16 '?' as placeholder for the generated hash
   # TODO: find out how the hash is generated and generate it internally for deterministic resolution
-  find /var/cache/dnf -mindepth 1 -maxdepth 1 -type d -name "${repo_name}-????????????????" ! -name "${repo_name}-*-*" | head -1
+  find /var/cache/dnf /var/tmp/dnf-* -mindepth 1 -maxdepth 1 -type d -name "${repo_name}-????????????????" ! -name "${repo_name}-*-*" 2>/dev/null | head -1
 }
 
 ## @fn run_from_dir()


### PR DESCRIPTION
Should Fix #3 .
Note that this is only a partial fix to unlock a situation for end-users that requires improvement: if `/var/cache/dnf` IS readable and a repository does exist, rpm-manager will use it despite the directory not being guaranteed to have been updated recently.