### PR TITLE
Fix read in gpg key download

### DIFF
--- a/src/download.sh
+++ b/src/download.sh
@@ -344,7 +344,7 @@ get_gpg_keys() {
     "$repo_file"
   )
   # Replace undesired values with spaces for proper array items detection
-  read -d $'0' -ra gpg_keys < <(awk "${awk_parameters[@]}" | sed -Ee 's/^gpgkey\s*=|[,\\]/ /g')
+  read -d $'\0' -ra gpg_keys < <(awk "${awk_parameters[@]}" | sed -Ee 's/^gpgkey\s*=|[,\\]/ /g')
 
   if test "${#gpg_keys[@]}" -eq 0; then
     return 1


### PR DESCRIPTION
Currently, gpg key downloads break if the remote url contains a `0`. The intent was probably to stop at the end of input instead, which is what this PR fixes.